### PR TITLE
Update the RBAC Model to least priv

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Use ACM PolicyGenerator with ArgoCD openshift-gitops to deliver multi-tenant isolation across managed OpenShift clusters. Tenancy boundaries — namespaces, RBAC, quotas, network isolation, MetalLB VRF/BGP — are all expressed as PolicyGenerator manifests and delivered through the default ArgoCD instance on the hub. No ACM Channels, Subscriptions or Applications are used.
 
 Policies are organised by NIST SP 800-53 control family:
-- **AC-Access-Control** — ACM fine-grained RBAC (`MulticlusterRoleAssignment`) for KubeVirt/VM access on managed clusters, hub `ClusterRoleBinding`s for ACM fleet console visibility, and managed-cluster `RoleBinding`s for Tenant-Admin/Tenant-Operator namespace access.
+- **AC-Access-Control** — ACM fine-grained RBAC (`MulticlusterRoleAssignment`) for KubeVirt/VM access on managed clusters, hub `ClusterRoleBinding`s for ACM fleet console visibility, and managed-cluster `RoleBinding`s for Tenant-Admin/Tenant-User/Tenant-Viewer namespace access.
 - **CM-Configuration-Management** — Creates tenant namespaces, ResourceQuotas, ApplicationAwareResourceQuotas (VM limits), LimitRanges, UserDefinedNetworks (OVN-isolated primary networks), and MetalLB BGP peering on managed clusters.
 - **SC-System-and-Communications-Protection** — Deploys the Tenant CRD and replicates Tenant CRs from the hub to managed clusters, establishing the foundation for all other tenant policies.
 

--- a/docs/new-tenant.md
+++ b/docs/new-tenant.md
@@ -10,7 +10,7 @@ Throughout this guide `**TENANT**` is used as a placeholder. Replace it with the
 
 ## 1. Decide on tenant parameters
 
-Fill in the table below before creating the Tenant CR. All fields except `adminGroup` and `operatorGroup` have sensible defaults.
+Fill in the table below before creating the Tenant CR. All fields except `adminGroup` and `userGroup` have sensible defaults.
 
 ### 1.1 Identity & RBAC
 
@@ -18,8 +18,9 @@ Fill in the table below before creating the Tenant CR. All fields except `adminG
 | Parameter          | Description                                                                                                       | Example              |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------- | -------------------- |
 | **Tenant name**    | Namespace name on managed clusters, used as prefix everywhere                                                     | `starwars`           |
-| **Tenant-Admin group**    | IdP group granted `admin` in the namespace + `kubevirt.io:admin` on VMs + `acm-vm-fleet:admin` on the hub console | `starwars-admins`    |
-| **Tenant-Operator group** | IdP group granted `edit` in the namespace + `kubevirt.io:edit` on VMs + `acm-vm-fleet:view` on the hub console    | `starwars-operators` |
+| **Tenant-Admin group**    | IdP group granted `admin` in the namespace + `kubevirt.io:admin` on VMs + `acm-vm-fleet:view` on the hub console  | `starwars-tenant-admin`  |
+| **Tenant-User group**     | IdP group granted `edit` in the namespace + `kubevirt.io:edit` on VMs + `acm-vm-fleet:view` on the hub console    | `starwars-tenant-user`   |
+| **Tenant-Viewer group**   | IdP group granted `view` in the namespace + `kubevirt.io:view` on VMs + `acm-vm-fleet:view` on the hub console    | `starwars-tenant-viewer` |
 
 
 Roles are fixed per group tier:
@@ -27,11 +28,12 @@ Roles are fixed per group tier:
 
 | Group tier       | Managed cluster namespace role | KubeVirt role       | ACM extended role       | ACM fleet console role |
 | ---------------- | ------------------------------ | ------------------- | ----------------------- | ---------------------- |
-| Tenant-Admin     | `admin`                        | `kubevirt.io:admin` | `acm-vm-extended:admin` | `acm-vm-fleet:admin`   |
-| Tenant-Operator  | `edit`                         | `kubevirt.io:edit`  | `acm-vm-extended:view`  | `acm-vm-fleet:view`    |
+| Tenant-Admin     | `admin`                        | `kubevirt.io:admin` | `acm-vm-extended:admin` | `acm-vm-fleet:view`    |
+| Tenant-User      | `edit`                         | `kubevirt.io:edit`  | `acm-vm-extended:view`  | `acm-vm-fleet:view`    |
+| Tenant-Viewer    | `view`                         | `kubevirt.io:view`  | `acm-vm-extended:view`  | `acm-vm-fleet:view`    |
 
 
-If you only need one group (e.g. no operator/view split), remove the operator RoleBinding and MulticlusterRoleAssignment blocks.
+The `viewerGroup` field is optional. If omitted, no viewer-tier resources are created. If you only need one group, remove the unused tiers from the Tenant CR.
 
 ### 1.2 ResourceQuota vs ApplicationAwareResourceQuota vs LimitRange
 
@@ -127,7 +129,7 @@ If the `network.metallb` section is omitted from the Tenant CR, no MetalLB resou
 
 ## 2. Create the Tenant CR
 
-Create a `Tenant` CR in the `tenancies` namespace on the hub. Only `adminGroup` and `operatorGroup` are required — all other fields have defaults from the CRD schema.
+Create a `Tenant` CR in the `tenancies` namespace on the hub. Only `adminGroup` and `userGroup` are required — all other fields have defaults from the CRD schema. The `viewerGroup` field is optional.
 
 Minimal example:
 
@@ -138,8 +140,9 @@ metadata:
   name: TENANT
   namespace: tenancies
 spec:
-  adminGroup: TENANT-admins
-  operatorGroup: TENANT-operators
+  adminGroup: TENANT-tenant-admin
+  userGroup: TENANT-tenant-user
+  viewerGroup: TENANT-tenant-viewer
 ```
 
 Full example with all fields: see [`examples/tenant-starwars.yaml`](../examples/tenant-starwars.yaml).
@@ -162,7 +165,7 @@ Once the Tenant CR is created, the policy evaluation cycle produces the followin
    - ResourceQuota, ApplicationAwareResourceQuota, LimitRange
    - UserDefinedNetwork (if `network.udnSubnet` is set)
    - MetalLB BGPPeer, IPAddressPool, BGPAdvertisement (if `network.metallb` is set)
-   - RoleBindings for Tenant-Admin and Tenant-Operator groups
+   - RoleBindings for Tenant-Admin, Tenant-User and Tenant-Viewer groups
 
 ---
 

--- a/docs/tenancy-model.md
+++ b/docs/tenancy-model.md
@@ -6,18 +6,21 @@ This document describes how the policies in this repository create tenant isolat
 
 ## 1. Personas and roles
 
-Four personas interact with the tenancy platform. The first two are per-tenant roles implemented by the RBAC templates in this repository. The second two are platform-wide roles managed outside the tenant boundary.
+Five personas interact with the tenancy platform. The first three are per-tenant roles implemented by the RBAC templates in this repository. The last two are platform-wide roles managed outside the tenant boundary.
 
 | Persona | Scope | Can do | Cannot do |
 |---|---|---|---|
-| **Tenant-Operator** | Per-tenant namespace | Start, stop, restart and access VMs; view namespace resources | Add or delete VMs, storage, or other resources; change quotas or RBAC |
+| **Tenant-Viewer** | Per-tenant namespace | View VMs and namespace resources in the ACM console | Start, stop, edit, create or delete VMs or any other resources |
+| **Tenant-User** | Per-tenant namespace | Start, stop, restart and access VMs; view namespace resources | Add or delete VMs, storage, or other resources; change quotas or RBAC |
 | **Tenant-Admin** | Per-tenant namespace | Add VMs, storage and services to the namespace; manage workloads | Change resource quotas, RBAC roles, or the tenant definition itself |
 | **Service Provider Operator** | Platform-wide | Create new tenancies; adjust quotas and tenant parameters | Change policies, tenancy architecture, or platform components |
 | **Service Provider Platform Admin** | Platform-wide | Change policies; add new components to the tenancy construct | Access namespaced tenant workloads directly |
 
-**Tenant-Admin** maps to the `adminGroup` field in the Tenant CRD and receives the Kubernetes `admin` ClusterRole in the tenant namespace, `kubevirt.io:admin` for VM operations, and `acm-vm-fleet:admin` for hub console visibility.
+**Tenant-Admin** maps to the `adminGroup` field in the Tenant CRD and receives the Kubernetes `admin` ClusterRole in the tenant namespace, `kubevirt.io:admin` for VM operations, and `acm-vm-fleet:view` for hub console visibility.
 
-**Tenant-Operator** maps to the `operatorGroup` field and receives the Kubernetes `edit` ClusterRole, `kubevirt.io:edit`, and `acm-vm-fleet:view`.
+**Tenant-User** maps to the `userGroup` field and receives the Kubernetes `edit` ClusterRole, `kubevirt.io:edit`, and `acm-vm-fleet:view`.
+
+**Tenant-Viewer** maps to the optional `viewerGroup` field and receives the Kubernetes `view` ClusterRole, `kubevirt.io:view`, and `acm-vm-fleet:view`. If `viewerGroup` is omitted from the Tenant CR, no viewer-tier resources are created.
 
 **Service Provider** roles are not per-tenant RBAC bindings. They are implemented through cluster-admin access, ArgoCD RBAC, and ACM hub console permissions. The tenancy construct enforces separation: a Service Provider Platform Admin can modify policies and tenancy definitions but has no RoleBinding in tenant namespaces; a Tenant-Admin has full namespace access but cannot alter quotas, policies, or the Tenant CRD.
 
@@ -45,10 +48,11 @@ All other controls — RBAC, quotas, network policies — are scoped to this nam
 
 `policygen/AC-Access-Control/rbac/managed-rolebindings.yaml`
 
-RoleBindings inside the tenant namespace grant the tenant's IdP groups permission to manage resources within that namespace only. Two tiers are provisioned per tenant:
+RoleBindings inside the tenant namespace grant the tenant's IdP groups permission to manage resources within that namespace only. Up to three tiers are provisioned per tenant:
 
 - **Tenant-Admin group** (`kubevirt.io:admin`, namespace `admin` role) — full control over VMs and namespace resources
-- **Tenant-Operator group** (`kubevirt.io:edit`, namespace `edit` role) — can run and modify VMs but cannot change RBAC or quotas
+- **Tenant-User group** (`kubevirt.io:edit`, namespace `edit` role) — can run and modify VMs but cannot change RBAC or quotas
+- **Tenant-Viewer group** (`kubevirt.io:view`, namespace `view` role) — read-only access to VMs and namespace resources (optional)
 
 These are standard Kubernetes RoleBindings — they grant no visibility into other tenants' namespaces, and no cluster-level permissions. Access to the ACM console and cross-cluster propagation is handled separately (see section 3).
 
@@ -86,14 +90,14 @@ flowchart TD
             vmA[VMs]
             quotaA["RQ + AAQ + LimitRange"]
             udnA["UDN A\n(primary isolated network)"]
-            rbacA["RoleBindings\n(Tenant-Admin + Tenant-Operator)"]
+            rbacA["RoleBindings\n(Admin + User + Viewer)"]
             metallbA["MetalLB BGP\n(VRF + BGPPeer + IPPool)"]
         end
         subgraph tenantB ["Namespace: startrek"]
             vmB[VMs]
             quotaB["RQ + AAQ + LimitRange"]
             udnB["UDN B\n(primary isolated network)"]
-            rbacB["RoleBindings\n(Tenant-Admin + Tenant-Operator)"]
+            rbacB["RoleBindings\n(Admin + User + Viewer)"]
             metallbB["MetalLB BGP\n(VRF + BGPPeer + IPPool)"]
         end
         tenantA -."no path between UDNs".- tenantB
@@ -126,14 +130,15 @@ Tenant users access their VMs through the ACM hub console without needing a dire
 
 `policygen/AC-Access-Control/policygenerator-hub.yaml`
 
-A `ClusterRoleBinding` on the hub grants each tenant group one of the `acm-vm-fleet` roles:
+A `ClusterRoleBinding` on the hub grants each tenant group the `acm-vm-fleet:view` role — the documented minimum for fleet virtualization console access (RHACM Scenario 2):
 
 | Group tier | Hub ClusterRole | Effect |
 |---|---|---|
-| Tenant-Admin | `acm-vm-fleet:admin` | Can see and manage their VM fleet in the ACM console |
-| Tenant-Operator | `acm-vm-fleet:view` | Read-only view of their VM fleet in the ACM console |
+| Tenant-Admin | `acm-vm-fleet:view` | Fleet virtualization console visibility |
+| Tenant-User | `acm-vm-fleet:view` | Fleet virtualization console visibility |
+| Tenant-Viewer | `acm-vm-fleet:view` | Fleet virtualization console visibility |
 
-This controls what the tenant sees in the ACM UI. Without it, the tenant group has no console visibility even if they have direct cluster access.
+This controls what the tenant sees in the ACM UI. Without it, the tenant group has no console visibility even if they have direct cluster access. The stronger `acm-vm-fleet:admin` role is only required for cross-cluster live migration and is intentionally not granted to tenant groups.
 
 ### Tier 2 — VM operations (managed clusters, via MulticlusterRoleAssignment)
 
@@ -144,9 +149,10 @@ A `MulticlusterRoleAssignment` (`rbac.open-cluster-management.io/v1beta1`) is cr
 | Group tier | KubeVirt role | ACM extended role |
 |---|---|---|
 | Tenant-Admin | `kubevirt.io:admin` | `acm-vm-extended:admin` |
-| Tenant-Operator | `kubevirt.io:edit` | `acm-vm-extended:view` |
+| Tenant-User | `kubevirt.io:edit` | `acm-vm-extended:view` |
+| Tenant-Viewer | `kubevirt.io:view` | `acm-vm-extended:view` |
 
-- `kubevirt.io:admin`/`edit` — allows the ACM console to proxy the VM's VNC and serial console on behalf of the user; also grants power operations (start, stop, restart, live migrate).
+- `kubevirt.io:admin`/`edit`/`view` — allows the ACM console to proxy the VM's VNC and serial console on behalf of the user (admin/edit); also grants power operations (start, stop, restart, live migrate). The `view` role grants read-only access.
 - `acm-vm-extended:admin`/`view` — grants access to extended VM management actions exposed through the ACM console (snapshots, clone, etc.).
 
 The tenant group **never needs a kubeconfig or direct API access** to the managed cluster. The ACM console acts as a proxy, and the `MulticlusterRoleAssignment` ensures the necessary authorisation is in place on the target cluster.
@@ -155,14 +161,14 @@ The tenant group **never needs a kubeconfig or direct API access** to the manage
 
 ```mermaid
 sequenceDiagram
-    participant user as "Tenant User\n(IdP group: starwars-admins)"
+    participant user as "Tenant User\n(IdP group: starwars-tenant-admin)"
     participant acm as "ACM Hub Console"
     participant hub as "Hub RBAC\n(ClusterRoleBinding)"
     participant mcra as "MulticlusterRoleAssignment\n(hub → managed)"
     participant kv as "Managed Cluster\n(KubeVirt)"
 
     user->>acm: Login via SSO
-    acm->>hub: Verify acm-vm-fleet:admin membership
+    acm->>hub: Verify acm-vm-fleet:view membership
     hub-->>acm: Authorised — show starwars fleet
     acm->>mcra: Resolve effective permissions for starwars namespace
     mcra-->>acm: kubevirt.io:admin + acm-vm-extended:admin on managed clusters
@@ -173,14 +179,16 @@ sequenceDiagram
 
 ### What each role allows
 
-| Action | acm-vm-fleet:admin | acm-vm-fleet:view | kubevirt.io:admin | kubevirt.io:edit |
+| Action | acm-vm-fleet:view (hub) | kubevirt.io:admin (managed) | kubevirt.io:edit (managed) | kubevirt.io:view (managed) |
 |---|:---:|:---:|:---:|:---:|
-| See VMs in ACM console | Y | Y | — | — |
-| Start / stop / restart VM | — | — | Y | Y |
-| Open VNC / serial console | — | — | Y | Y |
-| Edit VM spec | — | — | Y | Y |
-| Delete VM | — | — | Y | N |
-| View VM (read-only) | — | — | Y | Y |
+| See VMs in ACM console | Y | — | — | — |
+| Start / stop / restart VM | — | Y | Y | N |
+| Open VNC / serial console | — | Y | Y | N |
+| Edit VM spec | — | Y | Y | N |
+| Delete VM | — | Y | N | N |
+| View VM (read-only) | — | Y | Y | Y |
+
+Note: `acm-vm-fleet:admin` (not shown) is only required for cross-cluster live migration and is not granted to tenant groups.
 
 ---
 
@@ -198,7 +206,7 @@ This section is aimed at teams migrating from or familiar with vCloud Director. 
 | **MetalLB BGPPeer + IPAddressPool + VRF** | **vCD Edge Gateway + External Network** | Per-tenant north/south connectivity; distinct from UDN-to-UDN isolation. |
 | **RoleBinding** (`admin` / `edit` in namespace) | **vCD Org Administrator / vApp Author role** | Grants tenant users rights scoped to their Org/namespace. No cross-tenant visibility. |
 | **ACM MulticlusterRoleAssignment** (`kubevirt.io:admin`) | **vCD Organization Administrator** with VDC rights | Propagates KubeVirt VM management rights across clusters, scoped to the tenant namespace. Equivalent to giving an Org Admin the right to manage VMs within their Org VDC. |
-| **ACM fleet ClusterRoleBinding** (`acm-vm-fleet:admin`) | **vCD Tenant Portal access** for Org Administrators | Grants visibility into the management console (ACM / vCD tenant portal) for the tenant's group. Without it, the tenant cannot see the console even with underlying cluster rights. |
+| **ACM fleet ClusterRoleBinding** (`acm-vm-fleet:view`) | **vCD Tenant Portal access** for Org Administrators | Grants visibility into the management console (ACM / vCD tenant portal) for the tenant's group. Without it, the tenant cannot see the console even with underlying cluster rights. |
 | **KubeVirt VM console** (ACM proxied via `kubevirt.io:admin`) | **vCD VM Remote Console (VMRC)** via tenant portal | Browser-based VM console access proxied through the management plane. Neither the ACM user nor the vCD tenant user needs direct hypervisor access. |
 | **ACM Policy** (`remediationAction: enforce`) | **vCD Defined Entities / Org Policies** | Declarative enforcement — if a resource drifts from the desired state, ACM re-applies it. vCD Defined Entities provide similar schema-enforced resource governance within an Org. |
 
@@ -220,7 +228,7 @@ flowchart LR
         metallb["MetalLB BGPPeer +\nIPAddressPool + VRF"]
         udn["UserDefinedNetwork\n(primary isolation)"]
         console["KubeVirt console\n(ACM proxied)"]
-        fleetrole["acm-vm-fleet:admin\n+ MulticlusterRoleAssignment"]
+        fleetrole["acm-vm-fleet:view\n+ MulticlusterRoleAssignment"]
     end
 
     org <--> ns

--- a/policygen/AC-Access-Control/README.md
+++ b/policygen/AC-Access-Control/README.md
@@ -11,19 +11,21 @@ on both the ACM hub and managed clusters.
 Targets the hub cluster (`policies-placement-hub-clusters`) and creates ACM fine-grained
 RBAC resources directly from Tenant CRs:
 
-- **ClusterRoleBindings** for ACM console access via `acm-vm-fleet:{admin,view}` roles,
-  giving tenant groups visibility into their fleet through the ACM UI.
-- **MulticlusterRoleAssignments** that grant `kubevirt.io:{admin,edit}` and
-  `acm-vm-extended:{admin,view}` roles scoped to the tenant namespace on managed clusters.
-  These are ACM fine-grained RBAC resources evaluated on the hub and propagated to
-  matching clusters.
+- **ClusterRoleBindings** granting `acm-vm-fleet:view` to all three tenant groups
+  (admin, user, viewer) — the documented minimum for fleet virtualization console
+  access (RHACM Scenario 2). `acm-vm-fleet:admin` is not used as it is only
+  required for cross-cluster live migration.
+- **MulticlusterRoleAssignments** that grant `kubevirt.io:{admin,edit,view}` and
+  `acm-vm-extended:{admin,view}` roles scoped to the tenant namespace on managed
+  clusters. These are ACM fine-grained RBAC resources evaluated on the hub and
+  propagated to matching clusters.
 
 ### policygenerator-managed.yaml
 
 Targets managed clusters (`policies-placement-managed-clusters`) and creates:
 
-- **RoleBindings** in each tenant namespace granting `admin` to the tenant's Tenant-Admin
-  group and `edit` to the Tenant-Operator group.
+- **RoleBindings** in each tenant namespace granting `admin` to the Tenant-Admin
+  group, `edit` to the Tenant-User group, and `view` to the Tenant-Viewer group.
 
 This policy depends on `tenancy-managed-tenant-replication` (tenancies namespace) being Compliant,
 which ensures the Tenant CRD and replicated Tenant CRs are present before RoleBindings
@@ -49,8 +51,9 @@ metadata:
   name: newtenant
   namespace: tenancies
 spec:
-  adminGroup: newtenant-admins
-  operatorGroup: newtenant-operators
+  adminGroup: newtenant-tenant-admin
+  userGroup: newtenant-tenant-user
+  viewerGroup: newtenant-tenant-viewer
 ```
 
 No further edits are required. The hub policy re-evaluates, the Tenant CR is

--- a/policygen/AC-Access-Control/acm-finegrained-rbac/hub-fleet-crbs.yaml
+++ b/policygen/AC-Access-Control/acm-finegrained-rbac/hub-fleet-crbs.yaml
@@ -9,7 +9,7 @@ object-templates-raw: |
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: acm-vm-fleet:admin
+        name: acm-vm-fleet:view
       subjects:
         - kind: Group
           apiGroup: rbac.authorization.k8s.io
@@ -19,7 +19,7 @@ object-templates-raw: |
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: {{ $tenant.metadata.name }}-tenant-operator-acm-fleet
+        name: {{ $tenant.metadata.name }}-tenant-user-acm-fleet
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -27,5 +27,21 @@ object-templates-raw: |
       subjects:
         - kind: Group
           apiGroup: rbac.authorization.k8s.io
-          name: {{ $tenant.spec.operatorGroup }}
+          name: {{ $tenant.spec.userGroup }}
+  {{- if $tenant.spec.viewerGroup }}
+  - complianceType: mustonlyhave
+    objectDefinition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: {{ $tenant.metadata.name }}-tenant-viewer-acm-fleet
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: acm-vm-fleet:view
+      subjects:
+        - kind: Group
+          apiGroup: rbac.authorization.k8s.io
+          name: {{ $tenant.spec.viewerGroup }}
+  {{- end }}
   {{- end }}

--- a/policygen/AC-Access-Control/acm-finegrained-rbac/hub-mcra-virt.yaml
+++ b/policygen/AC-Access-Control/acm-finegrained-rbac/hub-mcra-virt.yaml
@@ -35,14 +35,14 @@ object-templates-raw: |
       apiVersion: rbac.open-cluster-management.io/v1beta1
       kind: MulticlusterRoleAssignment
       metadata:
-        name: {{ $tenant.metadata.name }}-tenant-operator-virt
+        name: {{ $tenant.metadata.name }}-tenant-user-virt
         namespace: policies
       spec:
         subject:
           kind: Group
-          name: {{ $tenant.spec.operatorGroup }}
+          name: {{ $tenant.spec.userGroup }}
         roleAssignments:
-        - name: {{ $tenant.metadata.name }}-tenant-operator-virt-kubevirt
+        - name: {{ $tenant.metadata.name }}-tenant-user-virt-kubevirt
           clusterRole: kubevirt.io:edit
           targetNamespaces:
           - {{ $tenant.metadata.name }}
@@ -51,7 +51,7 @@ object-templates-raw: |
             placements:
             - name: policies-placement-managed-clusters
               namespace: policies
-        - name: {{ $tenant.metadata.name }}-tenant-operator-virt-extended
+        - name: {{ $tenant.metadata.name }}-tenant-user-virt-extended
           clusterRole: acm-vm-extended:view
           targetNamespaces:
           - {{ $tenant.metadata.name }}
@@ -60,4 +60,36 @@ object-templates-raw: |
             placements:
             - name: policies-placement-managed-clusters
               namespace: policies
+  {{- if $tenant.spec.viewerGroup }}
+  - complianceType: mustonlyhave
+    objectDefinition:
+      apiVersion: rbac.open-cluster-management.io/v1beta1
+      kind: MulticlusterRoleAssignment
+      metadata:
+        name: {{ $tenant.metadata.name }}-tenant-viewer-virt
+        namespace: policies
+      spec:
+        subject:
+          kind: Group
+          name: {{ $tenant.spec.viewerGroup }}
+        roleAssignments:
+        - name: {{ $tenant.metadata.name }}-tenant-viewer-virt-kubevirt
+          clusterRole: kubevirt.io:view
+          targetNamespaces:
+          - {{ $tenant.metadata.name }}
+          clusterSelection:
+            type: placements
+            placements:
+            - name: policies-placement-managed-clusters
+              namespace: policies
+        - name: {{ $tenant.metadata.name }}-tenant-viewer-virt-extended
+          clusterRole: acm-vm-extended:view
+          targetNamespaces:
+          - {{ $tenant.metadata.name }}
+          clusterSelection:
+            type: placements
+            placements:
+            - name: policies-placement-managed-clusters
+              namespace: policies
+  {{- end }}
   {{- end }}

--- a/policygen/AC-Access-Control/policygenerator-managed.yaml
+++ b/policygen/AC-Access-Control/policygenerator-managed.yaml
@@ -23,7 +23,7 @@ policyDefaults:
 policies:
   - name: tenancy-managed-namespace-rbac
     controls:
-      - Enforce Namespace RBAC for Tenant-Admin and Tenant-Operator
+      - Enforce Namespace RBAC for Tenant-Admin, Tenant-User and Tenant-Viewer
     dependencies:
       - name: tenancy-managed-tenant-replication
         namespace: tenancies
@@ -34,6 +34,6 @@ policies:
 
 policySets:
   - name: tenancy-managed-access-control
-    description: Managed cluster namespace RoleBindings granting Tenant-Admin and Tenant-Operator access
+    description: Managed cluster namespace RoleBindings granting Tenant-Admin, Tenant-User and Tenant-Viewer access
     placement:
       placementName: policies-placement-managed-clusters

--- a/policygen/AC-Access-Control/rbac/managed-rolebindings.yaml
+++ b/policygen/AC-Access-Control/rbac/managed-rolebindings.yaml
@@ -21,7 +21,7 @@ object-templates-raw: |
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        name: {{ $name }}-tenant-operator
+        name: {{ $name }}-tenant-user
         namespace: {{ $name }}
       roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -30,5 +30,22 @@ object-templates-raw: |
       subjects:
         - kind: Group
           apiGroup: rbac.authorization.k8s.io
-          name: {{ $tenant.spec.operatorGroup }}
+          name: {{ $tenant.spec.userGroup }}
+  {{- if $tenant.spec.viewerGroup }}
+  - complianceType: mustonlyhave
+    objectDefinition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: {{ $name }}-tenant-viewer
+        namespace: {{ $name }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: view
+      subjects:
+        - kind: Group
+          apiGroup: rbac.authorization.k8s.io
+          name: {{ $tenant.spec.viewerGroup }}
+  {{- end }}
   {{- end }}

--- a/policygen/SC-System-and-Communications-Protection/keycloak/TODO.md
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/TODO.md
@@ -1,0 +1,97 @@
+# Keycloak Realm Policy — Future Work
+
+## Extend Tenant CRD with `keycloak` section
+
+Add optional per-tenant overrides to the Tenant CRD:
+
+- `keycloak.enabled` (boolean) — opt out of realm creation for specific tenants
+- `keycloak.namespace` (string) — target a different Keycloak instance namespace
+- `keycloak.instanceName` (string) — reference a Keycloak CR other than `main`
+- `keycloak.redirectUris` (array) — explicit OAuth callback URLs per tenant
+- `keycloak.seedAdmin.enabled` (boolean) — disable seed user creation
+
+This would allow multiple Keycloak instances serving different sets of tenants
+and per-tenant opt-out without removing the Tenant CR.
+
+## Client secret management
+
+The current implementation omits the OIDC client secret and uses a wildcard
+redirect URI. Production deployments require:
+
+- Generate or reference per-tenant OIDC client secrets via SealedSecrets,
+  External Secrets Operator, or HashiCorp Vault.
+- Create a corresponding `Secret` in `openshift-config` for each tenant so the
+  OpenShift OAuth server can complete the IdP handshake.
+- A new template (`client-secret-from-crd.yaml`) that iterates Tenant CRs and
+  emits Secrets in `openshift-config` with the client secret value.
+- Replace the wildcard `redirectUris: ["*"]` with the actual
+  `oauth-openshift.apps.<cluster>/oauth2callback/<tenant>-idp` callback URL.
+
+## Seed admin password hardening
+
+The bootstrap user currently uses a hardcoded `changeme` password with
+`temporary: true`. Stronger options:
+
+- **Per-tenant Secret lookup** — template uses `lookup` to read a Secret named
+  `{tenant}-seed-credentials` from the Keycloak namespace and injects the
+  password value. Secrets are provisioned out-of-band via Vault or
+  SealedSecrets.
+- **One-time password generation** — integrate with Vault's password generator
+  to produce a unique bootstrap password per tenant.
+- **Disable seed user post-bootstrap** — a follow-up policy or CronJob that
+  disables or deletes the seed user after the tenant admin has created their
+  own account.
+
+## OAuth IdP auto-registration
+
+Create a policy that patches `OAuth/cluster` to add a per-tenant IdP entry:
+
+```yaml
+- name: {tenant}-idp
+  type: OpenID
+  openID:
+    clientID: openshift-{tenant}
+    clientSecret:
+      name: {tenant}-client-secret
+    issuer: https://<keycloak-route>/realms/{tenant}
+    claims:
+      groups: [groups]
+      preferredUsername: [preferred_username]
+      name: [name]
+      email: [email]
+```
+
+This is complex because the `OAuth/cluster` resource is a singleton — the
+policy must merge IdP entries rather than replace the list. Consider using
+`musthave` with a partial object or a server-side apply strategy.
+
+## Group mapper automation
+
+Include the Group Membership protocol mapper in the realm import so that
+tokens automatically contain the `groups` claim without manual Keycloak
+console configuration:
+
+```yaml
+clientScopes:
+  - name: openshift-{tenant}-dedicated
+    protocol: openid-connect
+    protocolMappers:
+      - name: groups-mapper
+        protocol: openid-connect
+        protocolMapper: oidc-group-membership-mapper
+        config:
+          claim.name: groups
+          full.path: "false"
+          id.token.claim: "true"
+          access.token.claim: "true"
+```
+
+## Realm lifecycle
+
+- Handle tenant deletion and realm cleanup. Currently, removing a Tenant CR
+  leaves the Keycloak realm orphaned. Consider setting `pruneObjectBehavior:
+  DeleteAll` on the policy or implementing a finalizer-based cleanup.
+- Realm import is additive — the RHBK Operator does not remove groups, roles,
+  or users that were deleted from the import spec. Document this behavior and
+  consider periodic reconciliation via the Keycloak Admin API if strict
+  declarative management is required.

--- a/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
@@ -1,0 +1,49 @@
+object-templates-raw: |
+  {{- range $tenant := (lookup "dusty-seahorse.io/v1alpha1" "Tenant" "tenancies" "").items }}
+  {{- $name := $tenant.metadata.name }}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: k8s.keycloak.org/v2alpha1
+      kind: KeycloakRealmImport
+      metadata:
+        name: {{ $name }}-realm-import
+        namespace: keycloak-system
+      spec:
+        keycloakCRName: main
+        realm:
+          id: {{ $name }}
+          realm: {{ $name }}
+          enabled: true
+          groups:
+            - name: {{ $tenant.spec.adminGroup }}
+              path: /{{ $tenant.spec.adminGroup }}
+            - name: {{ $tenant.spec.userGroup }}
+              path: /{{ $tenant.spec.userGroup }}
+            {{- if $tenant.spec.viewerGroup }}
+            - name: {{ $tenant.spec.viewerGroup }}
+              path: /{{ $tenant.spec.viewerGroup }}
+            {{- end }}
+          roles:
+            realm:
+              - name: {{ $tenant.spec.adminGroup }}
+              - name: {{ $tenant.spec.userGroup }}
+              {{- if $tenant.spec.viewerGroup }}
+              - name: {{ $tenant.spec.viewerGroup }}
+              {{- end }}
+          users:
+            - username: {{ $name }}-admin
+              enabled: true
+              realmRoles:
+                - {{ $tenant.spec.adminGroup }}
+              credentials:
+                - type: password
+                  value: changeme
+                  temporary: true
+          clients:
+            - clientId: openshift-{{ $name }}
+              enabled: true
+              directAccessGrantsEnabled: true
+              standardFlowEnabled: true
+              redirectUris:
+                - "*"
+  {{- end }}

--- a/policygen/SC-System-and-Communications-Protection/policygenerator-hub.yaml
+++ b/policygen/SC-System-and-Communications-Protection/policygenerator-hub.yaml
@@ -28,6 +28,14 @@ policies:
       - path: tenancy/tenant-crd.yaml
       - path: tenancy/tenancies-namespace.yaml
 
+  - name: tenancy-hub-keycloak-realms
+    controls:
+      - Provision Tenant Keycloak Realms
+    dependencies:
+      - name: tenancy-hub-tenant-crd
+    manifests:
+      - path: keycloak/realm-import-from-crd.yaml
+
 policySets:
   - name: tenancy-hub-tenant-definition
     description: "Hub Tenant CRD and tenancies namespace -- foundation for all tenant policies"

--- a/policygen/SC-System-and-Communications-Protection/tenancy/tenant-crd.yaml
+++ b/policygen/SC-System-and-Communications-Protection/tenancy/tenant-crd.yaml
@@ -25,7 +25,7 @@ spec:
               type: object
               required:
                 - adminGroup
-                - operatorGroup
+                - userGroup
               properties:
                 # -----------------------------------------------------------
                 # Identity & RBAC
@@ -41,13 +41,22 @@ spec:
                   description: >-
                     Tenant-Admin IdP group — granted admin in the tenant
                     namespace, kubevirt.io:admin on VMs, and
-                    acm-vm-fleet:admin on the hub console.
-                operatorGroup:
+                    acm-vm-fleet:view on the hub console.
+                    Default naming convention: {tenantname}-tenant-admin.
+                userGroup:
                   type: string
                   description: >-
-                    Tenant-Operator IdP group — granted edit in the tenant
+                    Tenant-User IdP group — granted edit in the tenant
                     namespace, kubevirt.io:edit on VMs, and
                     acm-vm-fleet:view on the hub console.
+                    Default naming convention: {tenantname}-tenant-user.
+                viewerGroup:
+                  type: string
+                  description: >-
+                    Tenant-Viewer IdP group — granted view in the tenant
+                    namespace, kubevirt.io:view on VMs, and
+                    acm-vm-fleet:view on the hub console.
+                    Default naming convention: {tenantname}-tenant-viewer.
 
                 # -----------------------------------------------------------
                 # ResourceQuota — namespace totals (all pods + PVCs)
@@ -160,9 +169,12 @@ spec:
         - name: Admin Group
           type: string
           jsonPath: .spec.adminGroup
-        - name: Operator Group
+        - name: User Group
           type: string
-          jsonPath: .spec.operatorGroup
+          jsonPath: .spec.userGroup
+        - name: Viewer Group
+          type: string
+          jsonPath: .spec.viewerGroup
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp

--- a/tenancies/tenant-startrek.yaml
+++ b/tenancies/tenant-startrek.yaml
@@ -7,8 +7,9 @@ metadata:
 spec:
   displayName: "Star Trek"
   owner: platform-team@example.com
-  adminGroup: startrek-admins
-  operatorGroup: startrek-operators
+  adminGroup: startrek-tenant-admin
+  userGroup: startrek-tenant-user
+  viewerGroup: startrek-tenant-viewer
 
   resourceQuota:
     cpu: "86"

--- a/tenancies/tenant-starwars.yaml
+++ b/tenancies/tenant-starwars.yaml
@@ -7,8 +7,9 @@ metadata:
 spec:
   displayName: "Star Wars"
   owner: platform-team@example.com
-  adminGroup: starwars-admins
-  operatorGroup: starwars-operators
+  adminGroup: starwars-tenant-admin
+  userGroup: starwars-tenant-user
+  viewerGroup: starwars-tenant-viewer
 
   resourceQuota:
     cpu: "86"


### PR DESCRIPTION
kubevirt  fleet view only on hub
 add a viewer role to the policy and CRD
change the name of the tenant users group to be more consistent