### PR TITLE
Add opt-in tenant identity SSO (Keycloak + external OIDC) and align realm seed users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use ACM PolicyGenerator with ArgoCD openshift-gitops to deliver multi-tenant iso
 Policies are organised by NIST SP 800-53 control family:
 - **AC-Access-Control** — ACM fine-grained RBAC (`MulticlusterRoleAssignment`) for KubeVirt/VM access on managed clusters, hub `ClusterRoleBinding`s for ACM fleet console visibility, and managed-cluster `RoleBinding`s for Tenant-Admin/Tenant-User/Tenant-Viewer namespace access.
 - **CM-Configuration-Management** — Creates tenant namespaces, ResourceQuotas, ApplicationAwareResourceQuotas (VM limits), LimitRanges, UserDefinedNetworks (OVN-isolated primary networks), and MetalLB BGP peering on managed clusters.
-- **SC-System-and-Communications-Protection** — Deploys the Tenant CRD and replicates Tenant CRs from the hub to managed clusters, establishing the foundation for all other tenant policies.
+- **SC-System-and-Communications-Protection** — Deploys the Tenant CRD and replicates Tenant CRs from the hub to managed clusters, establishing the foundation for all other tenant policies. On the hub, also provisions baseline Keycloak realms (`admin@`, `user@`, `viewer@` at `<tenant>.local`) when Keycloak is installed.
 
 A custom `Tenant` CRD (`dusty-seahorse.io/v1alpha1`) in `tenancies/` provides the single source of truth for each tenant's identity, RBAC groups, quotas, and network settings. A hub-side policy in the `tenancies` namespace uses `{{hub range hub}}` templates to replicate every `Tenant` CR to managed clusters. Managed-cluster policies then iterate those local Tenant CRs with `{{ range }}` to create namespaces, quotas, network resources, and RoleBindings. Hub-side ACM fine-grained RBAC policies generate `MulticlusterRoleAssignment`s and `ClusterRoleBinding`s directly from the Tenant CRs — adding a tenant is just creating a CR.
 
@@ -53,7 +53,7 @@ Each ArgoCD Application syncs a `policygen/` folder. Kustomize runs the **Policy
 |---|---|---|
 | `tenancy-access-control` | AC | ClusterRoleBindings, MulticlusterRoleAssignments, namespace RoleBindings |
 | `tenancy-configuration-management` | CM | Namespaces, ResourceQuotas, AAQ, LimitRanges, UDNs, MetalLB BGP |
-| `tenancy-system-and-communications-protection` | SC | Tenant CRD, tenancies namespace, replicated Tenant CRs |
+| `tenancy-system-and-communications-protection` | SC | Tenant CRD, tenancies namespace, replicated Tenant CRs, hub Keycloak realm imports |
 | `tenancy-base` | — | Tenant CRs (source of truth) |
 | `tenancy-placements` | — | Placement rules for policy targeting |
 

--- a/docs/new-tenant.md
+++ b/docs/new-tenant.md
@@ -166,6 +166,15 @@ Once the Tenant CR is created, the policy evaluation cycle produces the followin
    - UserDefinedNetwork (if `network.udnSubnet` is set)
    - MetalLB BGPPeer, IPAddressPool, BGPAdvertisement (if `network.metallb` is set)
    - RoleBindings for Tenant-Admin, Tenant-User and Tenant-Viewer groups
+5. **Hub Keycloak policy** (`tenancy-hub-keycloak-realms`, when Keycloak is installed) creates a realm per tenant with seed users:
+
+   | Username | Password | Group |
+   |----------|----------|-------|
+   | `admin@<tenant>.local` | `password` | `<tenant>-tenant-admin` |
+   | `user@<tenant>.local` | `password` | `<tenant>-tenant-user` |
+   | `viewer@<tenant>.local` | `password` | `<tenant>-tenant-viewer` (if `viewerGroup` set) |
+
+   See [`policygen/SC-System-and-Communications-Protection/keycloak/README.md`](../policygen/SC-System-and-Communications-Protection/keycloak/README.md) for OIDC client and theme notes.
 
 ---
 

--- a/docs/new-tenant.md
+++ b/docs/new-tenant.md
@@ -203,15 +203,29 @@ oc get rolebinding -n TENANT
 
 ## 5. Removing a tenant
 
-Delete the Tenant CR from the hub:
+Delete the Tenant CR from the hub (ACM console or CLI):
 
 ```bash
 oc delete tenant TENANT -n tenancies
 ```
 
-On the next policy evaluation cycle:
+On the next policy / reconciler cycle:
 
-- The bridge ConfigMap is regenerated without the deleted tenant.
-- Hub ClusterRoleBindings and MulticlusterRoleAssignments for that tenant are no longer produced. Previously created hub resources must be cleaned up manually (or via a separate `mustnothave` policy) because `mustonlyhave` only enforces objects that the template produces.
-- Managed-cluster resources (Namespace, Quotas, RoleBindings, Network) are no longer produced by the templates. The CM Application has `prune: true` so ArgoCD will remove the generated policies, and ACM will then remove resources from managed clusters.
-- The AC Application has `prune: false` — RBAC removals require a manual sync with pruning or direct cleanup to avoid accidental access revocation during refactoring.
+| Resource | Auto-cleaned? | How |
+|----------|---------------|-----|
+| Bridge / managed-cluster templates | Yes | Tenant drops out of `lookup` range; CM policies stop producing spoke resources |
+| **KeycloakRealmImport** | Yes | `tenancy-hub-keycloak-realms` uses `pruneObjectBehavior: DeleteAll` |
+| **OAuth IdP** (`{tenant}-idp`) | Yes | Identity reconciler CronJob removes IdPs whose `openshift-{tenant}` client has no Tenant CR |
+| **Client secret** (`openshift-config/{tenant}-client-secret`) | Yes | Reconciler deletes default secret after removing orphan IdP |
+| **Custom theme** (ConfigMap + Keycloak mount) | No | Run `apply-themes.sh -d -t TENANT` in the demo repo |
+| **Hub ClusterRoleBindings / MCRAs** | No | AC Application has `prune: false` — remove manually or sync with prune |
+
+**Custom identity fields:** IdP/secret cleanup assumes default naming (`openshift-{tenant}` client, `{tenant}-client-secret`). Tenants with custom `clientId` or `clientSecretRef.name` may need manual OAuth/secret cleanup after delete.
+
+**Keycloak DB:** Deleting `KeycloakRealmImport` removes the CR; stale realm data in the Keycloak database may linger (RHBK is additive). Use the Keycloak admin API for strict DB cleanup if required.
+
+**Legacy theme-only tenants** (no `spec.identity`, created via `apply-themes.sh -r`): deleting the Tenant CR triggers policy realm-import prune; OAuth IdP cleanup uses the same `openshift-{tenant}` rule when the Tenant CR is gone.
+
+Previously created hub RBAC (see below) still requires manual cleanup:
+
+- Hub ClusterRoleBindings and MulticlusterRoleAssignments are no longer produced by templates. The AC Application has `prune: false` — remove manually or sync with pruning to avoid leaving fleet bindings in place.

--- a/examples/tenant-gigashadow-identity.yaml
+++ b/examples/tenant-gigashadow-identity.yaml
@@ -43,4 +43,5 @@ spec:
       namespace: keycloak-system
       instanceName: main
       realm: gigashadow
+      manageRealm: true
       seedUsers: true

--- a/examples/tenant-gigashadow-identity.yaml
+++ b/examples/tenant-gigashadow-identity.yaml
@@ -1,0 +1,46 @@
+---
+# Example tenant with opt-in console SSO (Keycloak).
+# Apply after creating the client secret:
+#   oc create secret generic gigashadow-client-secret -n openshift-config \
+#     --from-literal=clientSecret=VDRjA2vWjJwlSZQ9tickuGkBQpiiJHdN
+apiVersion: dusty-seahorse.io/v1alpha1
+kind: Tenant
+metadata:
+  name: gigashadow
+  namespace: tenancies
+spec:
+  displayName: "Gigashadow"
+  owner: platform-team@example.com
+  adminGroup: gigashadow-tenant-admin
+  userGroup: gigashadow-tenant-user
+  viewerGroup: gigashadow-tenant-viewer
+  resourceQuota:
+    cpu: "86"
+    memory: "332Gi"
+    pods: "15"
+    storage: "2000Gi"
+  vmQuota:
+    cpu: "80"
+    memory: "320Gi"
+  limitRange:
+    maxCpu: "32"
+    maxMemory: "128Gi"
+    maxStorage: "1Ti"
+  network:
+    udnSubnet: "10.128.0.0/16"
+    metallb:
+      myASN: 64500
+      vrf: gigashadow-vrf
+  identity:
+    enabled: true
+    provider: keycloak
+    consoleLoginName: gigashadow-idp
+    clientId: openshift-gigashadow
+    clientSecretRef:
+      name: gigashadow-client-secret
+      namespace: openshift-config
+    keycloak:
+      namespace: keycloak-system
+      instanceName: main
+      realm: gigashadow
+      seedUsers: true

--- a/policygen/README.md
+++ b/policygen/README.md
@@ -27,8 +27,9 @@ policygen/
 │
 └── SC-System-and-Communications-Protection/   Tenant isolation (SC)
     ├── kustomization.yaml           Registers policygenerator-*.yaml
-    ├── policygenerator-hub.yaml     Hub Tenant CRD + tenancies namespace
+    ├── policygenerator-hub.yaml     Hub Tenant CRD + tenancies namespace + Keycloak realms
     ├── policygenerator-managed.yaml Managed cluster Tenant CRD + CR replication
+    ├── keycloak/                    Hub KeycloakRealmImport from Tenant CRs (see keycloak/README.md)
     └── tenancy/                     Tenant CRD, tenancies namespace, hub-range bridge
 ```
 

--- a/policygen/SC-System-and-Communications-Protection/keycloak/README.md
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/README.md
@@ -67,6 +67,17 @@ this policy uses `remediationAction: enforce`; ACM will revert manual changes on
 the next sync. Use separate realm names for themed SSO demos (for example
 `mandalorian` instead of `starwars`).
 
+## Tenant deletion
+
+When a `Tenant` CR is deleted:
+
+1. **KeycloakRealmImport** — removed by `tenancy-hub-keycloak-realms` (`pruneObjectBehavior: DeleteAll`).
+2. **OAuth IdP + client secret** — removed by the identity reconciler CronJob for default `openshift-{tenant}` clients.
+3. **Custom CSS themes** — not removed by policy; run `apply-themes.sh -d -t <tenant>` in the demo repo.
+4. **Hub fleet RBAC** — manual cleanup (AC policy app has `prune: false`).
+
+The Keycloak **database** realm may persist after the import CR is deleted; see [TODO.md](TODO.md).
+
 ## Further work
 
 See [TODO.md](TODO.md) for client-secret lookup, OAuth IdP automation, and

--- a/policygen/SC-System-and-Communications-Protection/keycloak/README.md
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/README.md
@@ -1,0 +1,55 @@
+# Keycloak realm policy
+
+The `tenancy-hub-keycloak-realms` policy (hub only) creates a `KeycloakRealmImport`
+for every `Tenant` CR in the `tenancies` namespace. The template lives in
+`realm-import-from-crd.yaml` and is evaluated at policy sync time using `lookup`.
+
+## Seed users
+
+Each tenant realm is bootstrapped with three default users. Usernames use an
+email-style local part so they align with the `apply-themes.sh` onboarding format
+used in the ACM Keycloak demo.
+
+| Username | Group | Password | Notes |
+|----------|-------|----------|-------|
+| `admin@<tenant>.local` | `<tenant>-tenant-admin` from the Tenant CR | `password` | Admin tier |
+| `user@<tenant>.local` | `<tenant>-tenant-user` | `password` | Edit tier |
+| `viewer@<tenant>.local` | `<tenant>-tenant-viewer` | `password` | Omitted if `viewerGroup` is unset |
+
+Example for tenant `starwars`:
+
+- `admin@starwars.local` / `password` → group `starwars-tenant-admin`
+- `user@starwars.local` / `password` → group `starwars-tenant-user`
+- `viewer@starwars.local` / `password` → group `starwars-tenant-viewer`
+
+These users are **demo bootstrap accounts only**. Replace them with production
+identities (LDAP, OIDC federation, or Vault-generated credentials) before any
+real deployment.
+
+## OIDC client and OpenShift login
+
+Each realm includes an `openshift-<tenant>` client with:
+
+- Redirect URI: `https://oauth-openshift.<cluster-domain>/oauth2callback/<tenant>-idp`
+- Console wildcard: `https://console-openshift-console.<cluster-domain>/*`
+- Group membership mapper (`groups` claim, `full.path: false`)
+
+A matching client secret must exist in `openshift-config` and an IdP entry must
+be added to `oauth/cluster` before console SSO works. See the demo
+`acm-tenancy-keycloak` use case for the full handshake.
+
+## Custom login themes
+
+The template sets `loginTheme` to the tenant name (`bsg` when the tenant is
+`battlestar`). Custom CSS themes are **not** deployed by this policy — mount
+theme ConfigMaps separately or use `apply-themes.sh` for theme-only realms.
+
+**Do not** run themed realm imports for tenants that have a `Tenant` CR while
+this policy uses `remediationAction: enforce`; ACM will revert manual changes on
+the next sync. Use separate realm names for themed SSO demos (for example
+`mandalorian` instead of `starwars`).
+
+## Further work
+
+See [TODO.md](TODO.md) for client-secret lookup, OAuth IdP automation, and
+production hardening items.

--- a/policygen/SC-System-and-Communications-Protection/keycloak/README.md
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/README.md
@@ -1,84 +1,77 @@
 # Keycloak realm policy
 
 The `tenancy-hub-keycloak-realms` policy (hub only) creates a `KeycloakRealmImport`
-for every `Tenant` CR in the `tenancies` namespace. The template lives in
-`realm-import-from-crd.yaml` and is evaluated at policy sync time using `lookup`.
+**only when** `spec.identity.keycloak.manageRealm: true`. The identity reconciler
+registers OpenShift OAuth IdPs for all identity-enabled tenants regardless.
+
+## Production vs demo
+
+| Concern | Production (Argo SC policy) | Demo / workshop (outside or optional) |
+|---------|----------------------------|----------------------------------------|
+| OpenShift OAuth IdP | Identity reconciler CronJob | Same |
+| Keycloak realm CR | Only if `manageRealm: true` | Optional greenfield workshops |
+| Seed users | Only if `manageRealm` + `seedUsers: true` | Workshop bootstrap |
+| Custom CSS themes | **Not in policy** | `apply-themes.sh` in demo-setups |
+| Legacy franchise tenants (no `spec.identity`) | **Not in production policy** | Optional app `tenancy-sc-hub-demo` |
+
+### Production paths
+
+1. **External OIDC** (`provider: oidc`) — reconciler registers IdP; customer completes external app registration using `status.identity.externalSetupNotes`.
+2. **Existing customer Keycloak** (`provider: keycloak`, `manageRealm: false`) — customer realm and OIDC client already exist; platform stores client secret and registers OpenShift IdP against `https://<keycloak-route>/realms/<realm>`.
+3. **Greenfield Keycloak tenant** (`manageRealm: true`) — rare; creates realm, groups, optional seed users, and OAuth client via `KeycloakRealmImport`. Keycloak instance must already be installed.
+
+### Demo workshop path
+
+- Enable optional Argo app `tenancy-sc-hub-demo` for franchise tenants **without** `spec.identity` (starwars, startrek).
+- Use `apply-themes.sh` for CSS themes and Keycloak volume mounts — never part of production policy.
+- For ACM tenants with identity, set `manageRealm: true` and optionally `seedUsers: true` in the Create Tenant form.
 
 ## Opt-in console SSO (`spec.identity`)
 
-Tenants **without** `spec.identity` continue to receive Keycloak realm imports (legacy
-demo behaviour). New tenants should set `spec.identity.enabled: true` to opt in to
-full console SSO automation:
+Tenants **without** `spec.identity` are not enrolled in console SSO automation.
 
-| `provider` | Policy behaviour | IdP registration |
-|------------|------------------|------------------|
-| `keycloak` | `KeycloakRealmImport` on chosen Keycloak CR | CronJob adds `{tenant}-idp` to `oauth/cluster` |
-| `oidc` | No realm import | CronJob registers IdP; `status.identity` lists external setup notes |
+| `provider` | `manageRealm` | Policy behaviour | IdP registration |
+|------------|---------------|------------------|------------------|
+| `keycloak` | `false` | No realm import | CronJob adds `{tenant}-idp` to `oauth/cluster` |
+| `keycloak` | `true` | `KeycloakRealmImport` | CronJob adds IdP |
+| `oidc` | n/a | No realm import | CronJob adds IdP; external setup notes in status |
 
 Required fields when enabled:
 
 - `clientSecretRef` — Secret in `openshift-config` (create via form or CLI; never store the value on the CR)
-- `keycloak.namespace` / `keycloak.instanceName` — which Keycloak CR to use (demo default: `keycloak-system/main`)
+- `keycloak.namespace` / `keycloak.instanceName` — which Keycloak CR to use (must exist before SSO works)
 
 See [`examples/tenant-gigashadow-identity.yaml`](../../../examples/tenant-gigashadow-identity.yaml).
 
 ## Seed users
 
-Each tenant realm is bootstrapped with three default users. Usernames use an
-email-style local part so they align with the `apply-themes.sh` onboarding format
-used in the ACM Keycloak demo.
+When `manageRealm` and `seedUsers` are both true, each tenant realm is bootstrapped with demo users:
 
-| Username | Group | Password | Notes |
-|----------|-------|----------|-------|
-| `admin@<tenant>.local` | `<tenant>-tenant-admin` from the Tenant CR | `password` | Admin tier |
-| `user@<tenant>.local` | `<tenant>-tenant-user` | `password` | Edit tier |
-| `viewer@<tenant>.local` | `<tenant>-tenant-viewer` | `password` | Omitted if `viewerGroup` is unset |
+| Username | Group | Password |
+|----------|-------|----------|
+| `admin@<tenant>.local` | `<tenant>-tenant-admin` | `password` |
+| `user@<tenant>.local` | `<tenant>-tenant-user` | `password` |
+| `viewer@<tenant>.local` | `<tenant>-tenant-viewer` | `password` |
 
-Example for tenant `starwars`:
-
-- `admin@starwars.local` / `password` → group `starwars-tenant-admin`
-- `user@starwars.local` / `password` → group `starwars-tenant-user`
-- `viewer@starwars.local` / `password` → group `starwars-tenant-viewer`
-
-These users are **demo bootstrap accounts only**. Replace them with production
-identities (LDAP, OIDC federation, or Vault-generated credentials) before any
-real deployment.
+These are **workshop bootstrap accounts only**.
 
 ## OIDC client and OpenShift login
 
-Each realm includes an `openshift-<tenant>` client with:
-
-- Redirect URI: `https://oauth-openshift.<cluster-domain>/oauth2callback/<tenant>-idp`
-- Console wildcard: `https://console-openshift-console.<cluster-domain>/*`
-- Group membership mapper (`groups` claim, `full.path: false`)
-
-A matching client secret must exist in `openshift-config` and an IdP entry must
-be added to `oauth/cluster` before console SSO works. See the demo
-`acm-tenancy-keycloak` use case for the full handshake.
+Each managed realm includes an `openshift-<tenant>` client with console redirect URIs and a group mapper. When `manageRealm` is false, the customer must configure an equivalent client in their existing realm.
 
 ## Custom login themes
 
-The template sets `loginTheme` to the tenant name (`bsg` when the tenant is
-`battlestar`). Custom CSS themes are **not** deployed by this policy — mount
-theme ConfigMaps separately or use `apply-themes.sh` for theme-only realms.
-
-**Do not** run themed realm imports for tenants that have a `Tenant` CR while
-this policy uses `remediationAction: enforce`; ACM will revert manual changes on
-the next sync. Use separate realm names for themed SSO demos (for example
-`mandalorian` instead of `starwars`).
+Custom CSS is **not** deployed by production policy. Optional `spec.identity.keycloak.loginTheme` applies only when `manageRealm: true` (demo). Prefer `apply-themes.sh` for workshop themes.
 
 ## Tenant deletion
 
 When a `Tenant` CR is deleted:
 
-1. **KeycloakRealmImport** — removed by `tenancy-hub-keycloak-realms` (`pruneObjectBehavior: DeleteAll`).
-2. **OAuth IdP + client secret** — removed by the identity reconciler CronJob for default `openshift-{tenant}` clients.
-3. **Custom CSS themes** — not removed by policy; run `apply-themes.sh -d -t <tenant>` in the demo repo.
+1. **KeycloakRealmImport** — removed when `manageRealm` was true (`pruneObjectBehavior: DeleteAll`).
+2. **OAuth IdP + client secret** — removed by the identity reconciler CronJob.
+3. **Custom CSS themes** — run `apply-themes.sh -d -t <tenant>` in demo-setups.
 4. **Hub fleet RBAC** — manual cleanup (AC policy app has `prune: false`).
-
-The Keycloak **database** realm may persist after the import CR is deleted; see [TODO.md](TODO.md).
 
 ## Further work
 
-See [TODO.md](TODO.md) for client-secret lookup, OAuth IdP automation, and
-production hardening items.
+See [TODO.md](TODO.md).

--- a/policygen/SC-System-and-Communications-Protection/keycloak/README.md
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/README.md
@@ -4,6 +4,24 @@ The `tenancy-hub-keycloak-realms` policy (hub only) creates a `KeycloakRealmImpo
 for every `Tenant` CR in the `tenancies` namespace. The template lives in
 `realm-import-from-crd.yaml` and is evaluated at policy sync time using `lookup`.
 
+## Opt-in console SSO (`spec.identity`)
+
+Tenants **without** `spec.identity` continue to receive Keycloak realm imports (legacy
+demo behaviour). New tenants should set `spec.identity.enabled: true` to opt in to
+full console SSO automation:
+
+| `provider` | Policy behaviour | IdP registration |
+|------------|------------------|------------------|
+| `keycloak` | `KeycloakRealmImport` on chosen Keycloak CR | CronJob adds `{tenant}-idp` to `oauth/cluster` |
+| `oidc` | No realm import | CronJob registers IdP; `status.identity` lists external setup notes |
+
+Required fields when enabled:
+
+- `clientSecretRef` — Secret in `openshift-config` (create via form or CLI; never store the value on the CR)
+- `keycloak.namespace` / `keycloak.instanceName` — which Keycloak CR to use (demo default: `keycloak-system/main`)
+
+See [`examples/tenant-gigashadow-identity.yaml`](../../../examples/tenant-gigashadow-identity.yaml).
+
 ## Seed users
 
 Each tenant realm is bootstrapped with three default users. Usernames use an

--- a/policygen/SC-System-and-Communications-Protection/keycloak/TODO.md
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/TODO.md
@@ -69,8 +69,9 @@ the `.gitleaks.toml` allowlist entry.
 
 ## Seed admin password hardening
 
-The bootstrap user currently uses a hardcoded `changeme` password with
-`temporary: true`. Stronger options:
+The bootstrap users (`admin@`, `user@`, and optionally `viewer@` at
+`<tenant>.local`) currently share a demo password (`password`) with
+`temporary: false`. Stronger options:
 
 - **Per-tenant Secret lookup** — template uses `lookup` to read a Secret named
   `{tenant}-seed-credentials` from the Keycloak namespace and injects the

--- a/policygen/SC-System-and-Communications-Protection/keycloak/TODO.md
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/TODO.md
@@ -115,10 +115,10 @@ tokens.
 
 ## Realm lifecycle
 
-- Handle tenant deletion and realm cleanup. Currently, removing a Tenant CR
-  leaves the Keycloak realm orphaned. Consider setting `pruneObjectBehavior:
-  DeleteAll` on the policy or implementing a finalizer-based cleanup.
-- Realm import is additive — the RHBK Operator does not remove groups, roles,
-  or users that were deleted from the import spec. Document this behavior and
-  consider periodic reconciliation via the Keycloak Admin API if strict
-  declarative management is required.
+- **Tenant deletion:** `tenancy-hub-keycloak-realms` sets `pruneObjectBehavior: DeleteAll` so
+  `KeycloakRealmImport` CRs are removed when the Tenant CR is deleted. The identity reconciler
+  CronJob also removes orphan imports, OAuth IdPs (`openshift-{tenant}` clients), and default
+  client secrets.
+- **Keycloak DB:** Realm import is additive — the RHBK Operator does not remove groups, roles,
+  or users from the database when the import CR is deleted. Use the Keycloak Admin API for
+  strict DB cleanup if required.

--- a/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
@@ -11,7 +11,7 @@ metadata:
   name: tenant-identity-reconciler
 rules:
   - apiGroups: ["config.openshift.io"]
-    resources: ["oauths"]
+    resources: ["oauths", "ingresses"]
     verbs: ["get", "patch", "update"]
   - apiGroups: ["dusty-seahorse.io"]
     resources: ["tenants"]
@@ -49,20 +49,16 @@ data:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    SA=/var/run/secrets/kubernetes.io/serviceaccount
-    export KUBECONFIG=/tmp/kubeconfig
-    jq -n \
-      --arg token "$(cat "${SA}/token")" \
-      --arg server "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
-      --arg ca "${SA}/ca.crt" \
-      '{
-        apiVersion: "v1",
-        kind: "Config",
-        clusters: [{name: "in-cluster", cluster: {server: $server, "certificate-authority": $ca}}],
-        contexts: [{name: "in-cluster", context: {cluster: "in-cluster", user: "sa"}}],
-        "current-context": "in-cluster",
-        users: [{name: "sa", user: {token: $token}}]
-      }' > "${KUBECONFIG}"
+    if ! command -v jq >/dev/null 2>&1; then
+      case "$(uname -m)" in
+        x86_64) jq_bin=jq-linux-amd64 ;;
+        aarch64|arm64) jq_bin=jq-linux-arm64 ;;
+        *) echo "unsupported architecture for jq bootstrap: $(uname -m)" >&2; exit 1 ;;
+      esac
+      curl -fsSL -o /tmp/jq "https://github.com/jqlang/jq/releases/download/jq-1.7.1/${jq_bin}"
+      chmod +x /tmp/jq
+      export PATH="/tmp:${PATH}"
+    fi
 
     patch_status() {
       local ns=$1 name=$2 payload=$3

--- a/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
@@ -21,10 +21,13 @@ rules:
     verbs: ["get", "patch", "update"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "delete"]
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
     verbs: ["get", "list"]
+  - apiGroups: ["k8s.keycloak.org"]
+    resources: ["keycloakrealmimports"]
+    verbs: ["get", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -63,6 +66,55 @@ data:
     patch_status() {
       local ns=$1 name=$2 payload=$3
       oc patch tenant "$name" -n "$ns" --subresource=status --type=merge -p "$payload" 2>/dev/null || true
+    }
+
+    # Remove OpenShift OAuth IdPs and client secrets for tenants whose CR was deleted.
+    # Matches IdPs created by this reconciler (openID clientID openshift-{tenant}).
+    cleanup_orphan_identity_providers() {
+      local oauth_json tenant_names count idx cid idp_name tenant removed
+      oauth_json=$(oc get oauth cluster -o json)
+      tenant_names=$(oc get tenants.dusty-seahorse.io -n tenancies -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+      count=$(echo "$oauth_json" | jq '.spec.identityProviders | length')
+      removed=0
+      idx=$((count - 1))
+      while [ "$idx" -ge 0 ]; do
+        cid=$(echo "$oauth_json" | jq -r ".spec.identityProviders[$idx].openID.clientID // empty")
+        idp_name=$(echo "$oauth_json" | jq -r ".spec.identityProviders[$idx].name // empty")
+        if [ -n "$cid" ] && [[ "$cid" =~ ^openshift-(.+)$ ]]; then
+          tenant="${BASH_REMATCH[1]}"
+          if ! echo "$tenant_names" | grep -qx "$tenant"; then
+            echo "Removing orphan IdP ${idp_name} (client ${cid}, tenant ${tenant} deleted)"
+            if oc patch oauth cluster --type=json -p="[{\"op\":\"remove\",\"path\":\"/spec/identityProviders/${idx}\"}]"; then
+              removed=$((removed + 1))
+              oauth_json=$(oc get oauth cluster -o json)
+              if oc get secret "${tenant}-client-secret" -n openshift-config &>/dev/null; then
+                echo "Deleting orphan secret openshift-config/${tenant}-client-secret"
+                oc delete secret "${tenant}-client-secret" -n openshift-config
+              fi
+            fi
+          fi
+        fi
+        idx=$((idx - 1))
+      done
+      if [ "$removed" -gt 0 ]; then
+        echo "Removed ${removed} orphan identity provider(s)"
+      fi
+    }
+
+    # Fallback if policy prune lags: delete realm imports whose tenant CR is gone.
+    cleanup_orphan_realm_imports() {
+      while read -r import; do
+        name=$(echo "$import" | jq -r '.metadata.name')
+        ns=$(echo "$import" | jq -r '.metadata.namespace')
+        tenant="${name%-realm-import}"
+        if [ "$tenant" = "$name" ]; then
+          continue
+        fi
+        if ! oc get tenant "$tenant" -n tenancies &>/dev/null; then
+          echo "Deleting orphan KeycloakRealmImport ${ns}/${name}"
+          oc delete keycloakrealmimport "$name" -n "$ns" --ignore-not-found
+        fi
+      done < <(oc get keycloakrealmimport -A -o json 2>/dev/null | jq -c '.items[]?')
     }
 
     DOMAIN=$(oc get ingresses.config cluster -o jsonpath='{.spec.domain}')
@@ -157,6 +209,9 @@ data:
       patch_status "$NS" "$NAME" "$STATUS"
       echo "Reconciled tenant ${NAME} IdP ${IDP_NAME} (${PHASE})"
     done
+
+    cleanup_orphan_identity_providers
+    cleanup_orphan_realm_imports
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-identity-reconciler
+  namespace: tenancies
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tenant-identity-reconciler
+rules:
+  - apiGroups: ["config.openshift.io"]
+    resources: ["oauths"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["dusty-seahorse.io"]
+    resources: ["tenants"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["dusty-seahorse.io"]
+    resources: ["tenants/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tenant-identity-reconciler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tenant-identity-reconciler
+subjects:
+  - kind: ServiceAccount
+    name: tenant-identity-reconciler
+    namespace: tenancies
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tenant-identity-reconciler-script
+  namespace: tenancies
+data:
+  reconcile.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    shopt -s expand_aliases
+    alias oc='oc --insecure-skip-tls-verify=true'
+
+    patch_status() {
+      local ns=$1 name=$2 payload=$3
+      oc patch tenant "$name" -n "$ns" --subresource=status --type=merge -p "$payload" 2>/dev/null || true
+    }
+
+    DOMAIN=$(oc get ingresses.config cluster -o jsonpath='{.spec.domain}')
+    OAUTH_JSON=$(oc get oauth cluster -o json)
+
+    oc get tenants.dusty-seahorse.io -n tenancies -o json | jq -c '.items[]' | while read -r tenant; do
+      NAME=$(echo "$tenant" | jq -r '.metadata.name')
+      NS=$(echo "$tenant" | jq -r '.metadata.namespace')
+      IDENTITY=$(echo "$tenant" | jq -c '.spec.identity // empty')
+      if [ -z "$IDENTITY" ] || [ "$(echo "$IDENTITY" | jq -r '.enabled // false')" != "true" ]; then
+        continue
+      fi
+
+      PROVIDER=$(echo "$IDENTITY" | jq -r '.provider // "keycloak"')
+      IDP_NAME=$(echo "$IDENTITY" | jq -r ".consoleLoginName // \"${NAME}-idp\"")
+      CLIENT_ID=$(echo "$IDENTITY" | jq -r ".clientId // \"openshift-${NAME}\"")
+      SECRET_NS=$(echo "$IDENTITY" | jq -r '.clientSecretRef.namespace // "openshift-config"')
+      SECRET_NAME=$(echo "$IDENTITY" | jq -r ".clientSecretRef.name // \"${NAME}-client-secret\"")
+      CALLBACK="https://oauth-openshift.${DOMAIN}/oauth2callback/${IDP_NAME}"
+
+      if ! oc get secret "$SECRET_NAME" -n "$SECRET_NS" &>/dev/null; then
+        patch_status "$NS" "$NAME" "{\"status\":{\"identity\":{\"phase\":\"Error\",\"idpName\":\"${IDP_NAME}\",\"message\":\"Client secret ${SECRET_NS}/${SECRET_NAME} not found\"}}}"
+        continue
+      fi
+
+      ISSUER=""
+      NOTES="[]"
+      if [ "$PROVIDER" = "keycloak" ]; then
+        KC_NS=$(echo "$IDENTITY" | jq -r '.keycloak.namespace // "keycloak-system"')
+        REALM=$(echo "$IDENTITY" | jq -r ".keycloak.realm // \"${NAME}\"")
+        KC_HOST=$(oc get route keycloak -n "$KC_NS" -o jsonpath='{.spec.host}' 2>/dev/null || true)
+        if [ -z "$KC_HOST" ]; then
+          patch_status "$NS" "$NAME" "{\"status\":{\"identity\":{\"phase\":\"Error\",\"idpName\":\"${IDP_NAME}\",\"message\":\"Keycloak route not found in ${KC_NS}\"}}}"
+          continue
+        fi
+        ISSUER="https://${KC_HOST}/realms/${REALM}"
+      else
+        ISSUER=$(echo "$IDENTITY" | jq -r '.oidc.issuer // ""')
+        if [ -z "$ISSUER" ]; then
+          patch_status "$NS" "$NAME" "{\"status\":{\"identity\":{\"phase\":\"Error\",\"idpName\":\"${IDP_NAME}\",\"message\":\"spec.identity.oidc.issuer is required for provider oidc\"}}}"
+          continue
+        fi
+        NOTES=$(jq -nc --arg cb "$CALLBACK" --arg cid "$CLIENT_ID" --arg iss "$ISSUER" --arg ag "$(echo "$tenant" | jq -r '.spec.adminGroup')" \
+          '[
+            "Register redirect URI: " + $cb,
+            "Create OIDC client with ID: " + $cid,
+            "Set issuer to: " + $iss,
+            "Map groups claim to tenant groups (e.g. " + $ag + ")"
+          ]')
+      fi
+
+      EXISTS=$(echo "$OAUTH_JSON" | jq -r --arg n "$IDP_NAME" '[.spec.identityProviders[]? | select(.name == $n)] | length')
+      if [ "$EXISTS" = "0" ]; then
+        CLAIMS='{"preferredUsername":["preferred_username"],"name":["name"],"email":["email"],"groups":["groups"]}'
+        if [ "$PROVIDER" = "oidc" ]; then
+          G=$(echo "$IDENTITY" | jq -r '.oidc.claims.groups // "groups"')
+          U=$(echo "$IDENTITY" | jq -r '.oidc.claims.preferredUsername // "preferred_username"')
+          N=$(echo "$IDENTITY" | jq -r '.oidc.claims.name // "name"')
+          E=$(echo "$IDENTITY" | jq -r '.oidc.claims.email // "email"')
+          CLAIMS=$(jq -nc --arg g "$G" --arg u "$U" --arg n "$N" --arg e "$E" \
+            '{preferredUsername:[$u],name:[$n],email:[$e],groups:[$g]}')
+        fi
+        PATCH=$(jq -nc \
+          --arg name "$IDP_NAME" \
+          --arg cid "$CLIENT_ID" \
+          --arg sname "$SECRET_NAME" \
+          --arg issuer "$ISSUER" \
+          --argjson claims "$CLAIMS" \
+          '[{op:"add",path:"/spec/identityProviders/-",value:{
+            name:$name,mappingMethod:"claim",type:"OpenID",
+            openID:{clientID:$cid,clientSecret:{name:$sname},claims:$claims,issuer:$issuer}
+          }}]')
+        if ! oc patch oauth cluster --type=json -p "$PATCH"; then
+          patch_status "$NS" "$NAME" "{\"status\":{\"identity\":{\"phase\":\"Error\",\"idpName\":\"${IDP_NAME}\",\"message\":\"Failed to patch oauth/cluster\"}}}"
+          continue
+        fi
+        OAUTH_JSON=$(oc get oauth cluster -o json)
+      fi
+
+      PHASE="Ready"
+      if [ "$PROVIDER" = "oidc" ]; then
+        PHASE="PendingExternalSetup"
+      fi
+      STATUS=$(jq -nc \
+        --arg phase "$PHASE" \
+        --arg idp "$IDP_NAME" \
+        --arg cb "$CALLBACK" \
+        --arg iss "$ISSUER" \
+        --arg cid "$CLIENT_ID" \
+        --argjson notes "$NOTES" \
+        '{status:{identity:{phase:$phase,idpName:$idp,callbackURL:$cb,issuer:$iss,clientId:$cid,externalSetupNotes:$notes,message:"OpenShift IdP registered"}}}')
+      patch_status "$NS" "$NAME" "$STATUS"
+      echo "Reconciled tenant ${NAME} IdP ${IDP_NAME} (${PHASE})"
+    done
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tenant-identity-reconciler
+  namespace: tenancies
+spec:
+  schedule: "*/2 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: tenant-identity-reconciler
+          restartPolicy: OnFailure
+          containers:
+            - name: reconcile
+              image: quay.io/openshift/origin-cli:4.14
+              command: ["/bin/bash", "/scripts/reconcile.sh"]
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+          volumes:
+            - name: scripts
+              configMap:
+                name: tenant-identity-reconciler-script
+                defaultMode: 0755

--- a/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
@@ -48,15 +48,21 @@ data:
   reconcile.sh: |
     #!/usr/bin/env bash
     set -euo pipefail
-    shopt -s expand_aliases
 
-    # In-cluster oc config (service account token)
     SA=/var/run/secrets/kubernetes.io/serviceaccount
-    oc config set-cluster in-cluster --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" --certificate-authority="${SA}/ca.crt"
-    oc config set-credentials sa --token="$(cat "${SA}/token")"
-    oc config set-context in-cluster --cluster=in-cluster --user=sa
-    oc config use-context in-cluster
-    alias oc='oc --insecure-skip-tls-verify=true'
+    export KUBECONFIG=/tmp/kubeconfig
+    jq -n \
+      --arg token "$(cat "${SA}/token")" \
+      --arg server "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
+      --arg ca "${SA}/ca.crt" \
+      '{
+        apiVersion: "v1",
+        kind: "Config",
+        clusters: [{name: "in-cluster", cluster: {server: $server, "certificate-authority": $ca}}],
+        contexts: [{name: "in-cluster", context: {cluster: "in-cluster", user: "sa"}}],
+        "current-context": "in-cluster",
+        users: [{name: "sa", user: {token: $token}}]
+      }' > "${KUBECONFIG}"
 
     patch_status() {
       local ns=$1 name=$2 payload=$3
@@ -175,7 +181,7 @@ spec:
           containers:
             - name: reconcile
               image: quay.io/openshift/origin-cli:4.14
-              command: ["/bin/bash", "/scripts/reconcile.sh"]
+              command: ["/scripts/reconcile.sh"]
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts

--- a/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/identity-reconciler.yaml
@@ -49,6 +49,13 @@ data:
     #!/usr/bin/env bash
     set -euo pipefail
     shopt -s expand_aliases
+
+    # In-cluster oc config (service account token)
+    SA=/var/run/secrets/kubernetes.io/serviceaccount
+    oc config set-cluster in-cluster --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" --certificate-authority="${SA}/ca.crt"
+    oc config set-credentials sa --token="$(cat "${SA}/token")"
+    oc config set-context in-cluster --cluster=in-cluster --user=sa
+    oc config use-context in-cluster
     alias oc='oc --insecure-skip-tls-verify=true'
 
     patch_status() {

--- a/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
@@ -3,9 +3,7 @@ object-templates-raw: |
   {{- $name := $tenant.metadata.name }}
   {{- $identity := $tenant.spec.identity }}
   {{- $manageKeycloak := false }}
-  {{- if not $identity }}
-  {{- $manageKeycloak = true }}
-  {{- else if and $identity.enabled (eq ($identity.provider | default "keycloak") "keycloak") }}
+  {{- if and $identity $identity.enabled (eq ($identity.provider | default "keycloak") "keycloak") $identity.keycloak $identity.keycloak.manageRealm }}
   {{- $manageKeycloak = true }}
   {{- end }}
   {{- if not $manageKeycloak }}{{- else }}
@@ -13,19 +11,15 @@ object-templates-raw: |
   {{- $kcNs := "keycloak-system" }}
   {{- $kcCr := "main" }}
   {{- $realm := $name }}
-  {{- $seedUsers := true }}
+  {{- $seedUsers := false }}
   {{- if $identity.keycloak }}
   {{- if $identity.keycloak.namespace }}{{ $kcNs = $identity.keycloak.namespace }}{{- end }}
   {{- if $identity.keycloak.instanceName }}{{ $kcCr = $identity.keycloak.instanceName }}{{- end }}
   {{- if $identity.keycloak.realm }}{{ $realm = $identity.keycloak.realm }}{{- end }}
-  {{- if eq $identity.keycloak.seedUsers false }}{{ $seedUsers = false }}{{- end }}
+  {{- if $identity.keycloak.seedUsers }}{{ $seedUsers = true }}{{- end }}
   {{- end }}
-  {{- $loginTheme := $realm }}
-  {{- if eq $realm "battlestar" }}{{ $loginTheme = "bsg" }}{{ end }}
-  {{- if and $identity $identity.enabled }}
-  {{- $loginTheme = "keycloak" }}
+  {{- $loginTheme := "keycloak" }}
   {{- if and $identity.keycloak $identity.keycloak.loginTheme }}{{ $loginTheme = $identity.keycloak.loginTheme }}{{- end }}
-  {{- end }}
   {{- $secretNs := "openshift-config" }}
   {{- $secretName := printf "%s-client-secret" $name }}
   {{- if and $identity $identity.clientSecretRef $identity.clientSecretRef.name }}

--- a/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
@@ -2,6 +2,8 @@ object-templates-raw: |
   {{- range $tenant := (lookup "dusty-seahorse.io/v1alpha1" "Tenant" "tenancies" "").items }}
   {{- $name := $tenant.metadata.name }}
   {{- $domain := (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain }}
+  {{- $loginTheme := $name }}
+  {{- if eq $name "battlestar" }}{{ $loginTheme = "bsg" }}{{ end }}
   - complianceType: musthave
     objectDefinition:
       apiVersion: k8s.keycloak.org/v2alpha1
@@ -15,14 +17,21 @@ object-templates-raw: |
           id: {{ $name }}
           realm: {{ $name }}
           enabled: true
+          loginTheme: {{ $loginTheme }}
           groups:
             - name: {{ $tenant.spec.adminGroup }}
               path: /{{ $tenant.spec.adminGroup }}
+              realmRoles:
+                - {{ $tenant.spec.adminGroup }}
             - name: {{ $tenant.spec.userGroup }}
               path: /{{ $tenant.spec.userGroup }}
+              realmRoles:
+                - {{ $tenant.spec.userGroup }}
             {{- if $tenant.spec.viewerGroup }}
             - name: {{ $tenant.spec.viewerGroup }}
               path: /{{ $tenant.spec.viewerGroup }}
+              realmRoles:
+                - {{ $tenant.spec.viewerGroup }}
             {{- end }}
           roles:
             realm:
@@ -32,14 +41,38 @@ object-templates-raw: |
               - name: {{ $tenant.spec.viewerGroup }}
               {{- end }}
           users:
-            - username: {{ $name }}-admin
+            - username: admin@{{ $name }}.local
               enabled: true
-              realmRoles:
-                - {{ $tenant.spec.adminGroup }}
+              firstName: Admin
+              lastName: Default
+              groups:
+                - /{{ $tenant.spec.adminGroup }}
               credentials:
                 - type: password
-                  value: changeme
-                  temporary: true
+                  value: password
+                  temporary: false
+            - username: user@{{ $name }}.local
+              enabled: true
+              firstName: User
+              lastName: Default
+              groups:
+                - /{{ $tenant.spec.userGroup }}
+              credentials:
+                - type: password
+                  value: password
+                  temporary: false
+            {{- if $tenant.spec.viewerGroup }}
+            - username: viewer@{{ $name }}.local
+              enabled: true
+              firstName: Viewer
+              lastName: Default
+              groups:
+                - /{{ $tenant.spec.viewerGroup }}
+              credentials:
+                - type: password
+                  value: password
+                  temporary: false
+            {{- end }}
           clients:
             - clientId: openshift-{{ $name }}
               secret: VDRjA2vWjJwlSZQ9tickuGkBQpiiJHdN
@@ -48,6 +81,7 @@ object-templates-raw: |
               standardFlowEnabled: true
               redirectUris:
                 - "https://oauth-openshift.{{ $domain }}/oauth2callback/{{ $name }}-idp"
+                - "https://console-openshift-console.{{ $domain }}/*"
               protocolMappers:
                 - name: groups
                   protocol: openid-connect

--- a/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
@@ -1,21 +1,50 @@
 object-templates-raw: |
   {{- range $tenant := (lookup "dusty-seahorse.io/v1alpha1" "Tenant" "tenancies" "").items }}
   {{- $name := $tenant.metadata.name }}
+  {{- $identity := $tenant.spec.identity }}
+  {{- $manageKeycloak := false }}
+  {{- if not $identity }}
+  {{- $manageKeycloak = true }}
+  {{- else if and $identity.enabled (eq ($identity.provider | default "keycloak") "keycloak") }}
+  {{- $manageKeycloak = true }}
+  {{- end }}
+  {{- if not $manageKeycloak }}{{- else }}
   {{- $domain := (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain }}
-  {{- $loginTheme := $name }}
-  {{- if eq $name "battlestar" }}{{ $loginTheme = "bsg" }}{{ end }}
+  {{- $kcNs := "keycloak-system" }}
+  {{- $kcCr := "main" }}
+  {{- $realm := $name }}
+  {{- $seedUsers := true }}
+  {{- if $identity.keycloak }}
+  {{- if $identity.keycloak.namespace }}{{ $kcNs = $identity.keycloak.namespace }}{{- end }}
+  {{- if $identity.keycloak.instanceName }}{{ $kcCr = $identity.keycloak.instanceName }}{{- end }}
+  {{- if $identity.keycloak.realm }}{{ $realm = $identity.keycloak.realm }}{{- end }}
+  {{- if eq $identity.keycloak.seedUsers false }}{{ $seedUsers = false }}{{- end }}
+  {{- end }}
+  {{- $loginTheme := $realm }}
+  {{- if eq $realm "battlestar" }}{{ $loginTheme = "bsg" }}{{ end }}
+  {{- $secretNs := "openshift-config" }}
+  {{- $secretName := printf "%s-client-secret" $name }}
+  {{- if and $identity $identity.clientSecretRef $identity.clientSecretRef.name }}
+  {{- $secretName = $identity.clientSecretRef.name }}
+  {{- if $identity.clientSecretRef.namespace }}{{ $secretNs = $identity.clientSecretRef.namespace }}{{- end }}
+  {{- end }}
+  {{- $clientSecret := "VDRjA2vWjJwlSZQ9tickuGkBQpiiJHdN" }}
+  {{- $secret := lookup "v1" "Secret" $secretNs $secretName }}
+  {{- if $secret }}{{ $clientSecret = ($secret.data.clientSecret | b64dec) }}{{- end }}
+  {{- $idpName := printf "%s-idp" $name }}
+  {{- if and $identity $identity.consoleLoginName }}{{ $idpName = $identity.consoleLoginName }}{{- end }}
   - complianceType: musthave
     objectDefinition:
       apiVersion: k8s.keycloak.org/v2alpha1
       kind: KeycloakRealmImport
       metadata:
         name: {{ $name }}-realm-import
-        namespace: keycloak-system
+        namespace: {{ $kcNs }}
       spec:
-        keycloakCRName: main
+        keycloakCRName: {{ $kcCr }}
         realm:
-          id: {{ $name }}
-          realm: {{ $name }}
+          id: {{ $realm }}
+          realm: {{ $realm }}
           enabled: true
           loginTheme: {{ $loginTheme }}
           groups:
@@ -40,6 +69,7 @@ object-templates-raw: |
               {{- if $tenant.spec.viewerGroup }}
               - name: {{ $tenant.spec.viewerGroup }}
               {{- end }}
+          {{- if $seedUsers }}
           users:
             - username: admin@{{ $name }}.local
               enabled: true
@@ -73,14 +103,15 @@ object-templates-raw: |
                   value: password
                   temporary: false
             {{- end }}
+          {{- end }}
           clients:
-            - clientId: openshift-{{ $name }}
-              secret: VDRjA2vWjJwlSZQ9tickuGkBQpiiJHdN
+            - clientId: {{ if and $identity $identity.clientId }}{{ $identity.clientId }}{{ else }}openshift-{{ $name }}{{ end }}
+              secret: {{ $clientSecret }}
               enabled: true
               directAccessGrantsEnabled: true
               standardFlowEnabled: true
               redirectUris:
-                - "https://oauth-openshift.{{ $domain }}/oauth2callback/{{ $name }}-idp"
+                - "https://oauth-openshift.{{ $domain }}/oauth2callback/{{ $idpName }}"
                 - "https://console-openshift-console.{{ $domain }}/*"
               protocolMappers:
                 - name: groups
@@ -93,4 +124,5 @@ object-templates-raw: |
                     id.token.claim: "true"
                     access.token.claim: "true"
                     userinfo.token.claim: "true"
+  {{- end }}
   {{- end }}

--- a/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
+++ b/policygen/SC-System-and-Communications-Protection/keycloak/realm-import-from-crd.yaml
@@ -22,6 +22,10 @@ object-templates-raw: |
   {{- end }}
   {{- $loginTheme := $realm }}
   {{- if eq $realm "battlestar" }}{{ $loginTheme = "bsg" }}{{ end }}
+  {{- if and $identity $identity.enabled }}
+  {{- $loginTheme = "keycloak" }}
+  {{- if and $identity.keycloak $identity.keycloak.loginTheme }}{{ $loginTheme = $identity.keycloak.loginTheme }}{{- end }}
+  {{- end }}
   {{- $secretNs := "openshift-config" }}
   {{- $secretName := printf "%s-client-secret" $name }}
   {{- if and $identity $identity.clientSecretRef $identity.clientSecretRef.name }}

--- a/policygen/SC-System-and-Communications-Protection/policygenerator-hub.yaml
+++ b/policygen/SC-System-and-Communications-Protection/policygenerator-hub.yaml
@@ -37,6 +37,14 @@ policies:
     manifests:
       - path: keycloak/realm-import-from-crd.yaml
 
+  - name: tenancy-hub-identity-reconciler
+    controls:
+      - Register Tenant OpenShift OAuth IdPs
+    dependencies:
+      - name: tenancy-hub-tenant-crd
+    manifests:
+      - path: keycloak/identity-reconciler.yaml
+
 policySets:
   - name: tenancy-hub-tenant-definition
     description: "Hub Tenant CRD and tenancies namespace -- foundation for all tenant policies"

--- a/policygen/SC-System-and-Communications-Protection/policygenerator-hub.yaml
+++ b/policygen/SC-System-and-Communications-Protection/policygenerator-hub.yaml
@@ -31,7 +31,7 @@ policies:
 
   - name: tenancy-hub-keycloak-realms
     controls:
-      - Provision Tenant Keycloak Realms
+      - Provision Tenant Keycloak Realms (opt-in manageRealm only)
     dependencies:
       - name: tenancy-hub-tenant-crd
     # Remove KeycloakRealmImport CRs when the Tenant CR is deleted.

--- a/policygen/SC-System-and-Communications-Protection/policygenerator-hub.yaml
+++ b/policygen/SC-System-and-Communications-Protection/policygenerator-hub.yaml
@@ -34,6 +34,8 @@ policies:
       - Provision Tenant Keycloak Realms
     dependencies:
       - name: tenancy-hub-tenant-crd
+    # Remove KeycloakRealmImport CRs when the Tenant CR is deleted.
+    pruneObjectBehavior: DeleteAll
     manifests:
       - path: keycloak/realm-import-from-crd.yaml
 

--- a/policygen/SC-System-and-Communications-Protection/tenancy/tenant-crd.yaml
+++ b/policygen/SC-System-and-Communications-Protection/tenancy/tenant-crd.yaml
@@ -127,17 +127,31 @@ spec:
                         namespace:
                           type: string
                           default: keycloak-system
+                          description: Namespace of the Keycloak CR (must already exist).
                         instanceName:
                           type: string
                           default: main
                           description: Keycloak CR name (keycloakCRName).
                         realm:
                           type: string
-                          description: Realm name. Defaults to tenant name.
+                          description: Existing realm name for OAuth issuer. Defaults to tenant name.
+                        manageRealm:
+                          type: boolean
+                          default: false
+                          description: >-
+                            When true, create/update a KeycloakRealmImport for this tenant.
+                            Leave false when the realm already exists (typical production).
                         seedUsers:
                           type: boolean
-                          default: true
-                          description: Create admin@/user@/viewer@ demo seed users.
+                          default: false
+                          description: >-
+                            When manageRealm is true, create admin@/user@/viewer@ demo users.
+                            Workshop use only — not for production.
+                        loginTheme:
+                          type: string
+                          description: >-
+                            Optional login theme on managed realms. Demo workshops only;
+                            custom CSS themes are applied outside policy (apply-themes.sh).
                     oidc:
                       type: object
                       description: External OIDC settings when provider is oidc.

--- a/policygen/SC-System-and-Communications-Protection/tenancy/tenant-crd.yaml
+++ b/policygen/SC-System-and-Communications-Protection/tenancy/tenant-crd.yaml
@@ -17,10 +17,35 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      subresources:
+        status: {}
       schema:
         openAPIV3Schema:
           type: object
           properties:
+            status:
+              type: object
+              properties:
+                identity:
+                  type: object
+                  properties:
+                    phase:
+                      type: string
+                      description: Pending, Ready, PendingExternalSetup, or Error.
+                    idpName:
+                      type: string
+                    callbackURL:
+                      type: string
+                    issuer:
+                      type: string
+                    clientId:
+                      type: string
+                    message:
+                      type: string
+                    externalSetupNotes:
+                      type: array
+                      items:
+                        type: string
             spec:
               type: object
               required:
@@ -57,6 +82,74 @@ spec:
                     namespace, kubevirt.io:view on VMs, and
                     acm-vm-fleet:view on the hub console.
                     Default naming convention: {tenantname}-tenant-viewer.
+
+                # -----------------------------------------------------------
+                # Optional console SSO (OpenShift OAuth IdP)
+                # -----------------------------------------------------------
+                identity:
+                  type: object
+                  description: >-
+                    Optional OpenShift console login integration. When enabled,
+                    policies provision Keycloak realms (provider=keycloak) or
+                    register external OIDC IdPs and surface setup notes in status.
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: false
+                      description: Enable console SSO for this tenant.
+                    provider:
+                      type: string
+                      enum:
+                        - keycloak
+                        - oidc
+                      description: keycloak = platform-managed realm; oidc = external IdP (Azure, etc.).
+                    consoleLoginName:
+                      type: string
+                      description: OpenShift OAuth identity provider name. Defaults to {tenant}-idp.
+                    clientId:
+                      type: string
+                      description: OIDC client ID. Defaults to openshift-{tenant}.
+                    clientSecretRef:
+                      type: object
+                      description: Secret holding the OIDC client secret (openshift-config).
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                          default: openshift-config
+                      required:
+                        - name
+                    keycloak:
+                      type: object
+                      description: Keycloak options when provider is keycloak.
+                      properties:
+                        namespace:
+                          type: string
+                          default: keycloak-system
+                        instanceName:
+                          type: string
+                          default: main
+                          description: Keycloak CR name (keycloakCRName).
+                        realm:
+                          type: string
+                          description: Realm name. Defaults to tenant name.
+                        seedUsers:
+                          type: boolean
+                          default: true
+                          description: Create admin@/user@/viewer@ demo seed users.
+                    oidc:
+                      type: object
+                      description: External OIDC settings when provider is oidc.
+                      properties:
+                        issuer:
+                          type: string
+                          description: Issuer URL (e.g. Azure AD v2 endpoint).
+                        claims:
+                          type: object
+                          additionalProperties:
+                            type: string
+                          description: Claim mappings (groups, preferredUsername, name, email).
 
                 # -----------------------------------------------------------
                 # ResourceQuota — namespace totals (all pods + PVCs)


### PR DESCRIPTION
## Summary

This PR adds opt-in console SSO for ACM tenants and aligns the Keycloak realm policy with the demo `apply-themes.sh` user model.

- **Tenant CRD:** new `spec.identity` (Keycloak or external OIDC) and `status.identity` (phase, IdP name, callback URL, external setup notes)
- **Keycloak realm policy:** conditional realm imports for identity-enabled tenants; email-style seed users (`admin@`, `user@`, `viewer@` at `<tenant>.local`, password `password`); group `realmRoles`; console OAuth redirect URIs
- **Identity reconciler:** CronJob registers OpenShift OAuth IdPs, patches tenant status, and reads client secrets from `openshift-config`
- **loginTheme:** identity tenants default to `keycloak`; legacy tenants without `spec.identity` keep realm-named themes; optional `spec.identity.keycloak.loginTheme` for custom CSS themes via `apply-themes.sh`
- **Docs/examples:** `examples/tenant-gigashadow-identity.yaml`, updates to `docs/new-tenant.md` and `keycloak/README.md`

## Motivation

ACM tenancy demos need console login per tenant without hand-maintaining Keycloak realms and OAuth IdPs. Opt-in `spec.identity` lets the policy own realm + IdP provisioning while `apply-themes.sh` can still mount custom CSS for ACM-managed tenants.

## Test plan

- [ ] Argo sync `tenancy-system-and-communications-protection` from this branch
- [ ] Create client secret in `openshift-config` (see `examples/tenant-gigashadow-identity.yaml`)
- [ ] Apply example tenant with `spec.identity.provider: keycloak`
- [ ] Verify Keycloak realm in `keycloak-system`, OAuth IdP on cluster, `status.identity.phase: Ready`
- [ ] Console login via tenant IdP (use incognito / clear OAuth cookies if state errors appear)
- [ ] Confirm legacy tenants without `spec.identity` still get realm-named `loginTheme`
- [ ] (Optional) Apply tenant with external OIDC and confirm `PendingExternalSetup` status + setup notes

## Related PRs

- https://github.com/ngner/tenant-form-acm-gui/pull/6 — Create Tenant form UI
- https://github.com/ngner/demo-setups/pull/10 — submodule pointers + `apply-themes.sh` ACM integration
